### PR TITLE
Migrate to LDAP-module v2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,16 +16,6 @@ jobs:
     runs-on: [ubuntu-latest]
 
     steps:
-      - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
-        with:
-          php-version: '8.0'
-          tools: composer:v2
-          extensions: intl, mbstring, xml
-
-      - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
-
       - uses: actions/checkout@v3
 
       - name: Lint markdown files
@@ -33,3 +23,31 @@ jobs:
         with:
           files: .
           ignore_path: .markdownlintignore
+
+      - name: Perform spell check
+        uses: codespell-project/actions-codespell@master
+        with:
+          path: '**/*.md'
+          check_filenames: true
+          ignore_words_list: tekst
+
+  build:
+    name: Build documentation
+    needs: quality
+    runs-on: [ubuntu-latest]
+
+    steps:
+      - name: Run docs build
+        if: github.event_name != 'pull_request'
+        uses: actions/github-script@v6
+        with:
+          # Token has to be generated on a user account that controls the docs-repository.
+          # The _only_ scope to select is "Access public repositories", nothing more.
+          github-token: ${{ secrets.PAT_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: 'simplesamlphp',
+              repo: 'docs',
+              workflow_id: 'mk_docs.yml',
+              ref: 'main'
+            })

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
         "ext-krb5": ">=1.1.4",
 
         "simplesamlphp/composer-module-installer": "~1.1",
-        "simplesamlphp/simplesamlphp": "^2.0.0-beta.11",
-        "simplesamlphp/simplesamlphp-module-ldap": "^1.2"
+        "simplesamlphp/simplesamlphp": "^2.0.0-rc2",
+        "simplesamlphp/simplesamlphp-module-ldap": "dev-fromAuthSource"
     },
     "require-dev": {
         "simplesamlphp/simplesamlphp-test-framework": "^1.2.1"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 
         "simplesamlphp/composer-module-installer": "~1.1",
         "simplesamlphp/simplesamlphp": "^2.0.0-rc2",
-        "simplesamlphp/simplesamlphp-module-ldap": "dev-fromAuthSource"
+        "simplesamlphp/simplesamlphp-module-ldap": "^2.1.0"
     },
     "require-dev": {
         "simplesamlphp/simplesamlphp-test-framework": "^1.2.1"

--- a/docs/negotiate.md
+++ b/docs/negotiate.md
@@ -53,16 +53,25 @@ All configuration is handled in authsources.php:
 'weblogin' => [
     'negotiate:Negotiate',
     'keytab' => '/path/to/keytab-file',
-    'fallback' => 'ldap',
-    'spn' => null
+    'backend' => 'ldap',
+    'fallback' => 'crypto-hash',
+    'spn' => null,
 ],
 'ldap' => [
     'ldap:LDAP',
     'hostname' => 'ldap.example.com',
     'enable_tls' => true,
     'dnpattern' => 'uid=%username%,cn=people,dc=example,dc=com',
-    'search.enable' => false
+    'search.enable' => false,
 ],
+'crypto-hash' => [
+    'authcrypt:Hash',
+    // hashed version of 'verysecret', made with bin/pwgen.php
+    'professor:{SSHA256}P6FDTEEIY2EnER9a6P2GwHhI5JDrwBgjQ913oVQjBngmCtrNBUMowA==' => [
+        'uid' => ['prof_a'],
+        'eduPersonAffiliation' => ['member', 'employee', 'board'],
+    ],
+]
 ```
 
 ### `php_krb5`

--- a/docs/negotiate.md
+++ b/docs/negotiate.md
@@ -160,7 +160,7 @@ conditions. This triggers a popup login box which defeats the whole
 purpose of this module.
 
 TBD: Replace or supplement with LDAP lookups in the domain. Machines
-currently in the domain should be the only ones that are promted with
+currently in the domain should be the only ones that are prompted with
 WWW-Authenticate: Negotiate.
 
 ### Enabling/disabling Negotiate from a web browser

--- a/docs/negotiate.md
+++ b/docs/negotiate.md
@@ -54,11 +54,6 @@ All configuration is handled in authsources.php:
     'negotiate:Negotiate',
     'keytab' => '/path/to/keytab-file',
     'fallback' => 'ldap',
-    'hostname' => 'ldap.example.com',
-    'base' => 'cn=people,dc=example,dc=com',
-    'adminUser' => 'cn=idp-fallback,cn=services,dc=example,dc=com',
-    'adminPassword' => 'VerySecretPassphraseHush',
-    'referrals' => true,
     'spn' => null
 ],
 'ldap' => [
@@ -78,7 +73,6 @@ by php_krb5.
 NOTE! If running using virtual hosts or behind a reverse proxy, you
 might need to change the 'spn' variable to 0 (match any entry in the
 keytab file) or set it to the specific entry you are trying to match.
-This requires php-krb5 >= 1.1.3:
 
 ```php
 'spn' => 'HTTP/host',
@@ -135,18 +129,9 @@ if (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
 LDAP is used to verify the user due to the lack of metadata in
 Kerberos. A domain can contain lots of kiosk users, non-personal
 accounts and the likes. The LDAP lookup will authorize and fetch
-attributes as defined by SimpleSamlPhp metadata.
+attributes as defined by SimpleSAMLphp metadata.
 
-'hostname', 'enable_tls', 'debugLDAP', 'timeout', 'base' and
-'referrals' are self-explanatory. Read the documentation of the LDAP
-auth module for more information. 'attr' is the attribute that will
-be used to look up user objects in the directory after extracting it
-from the Kerberos session. Default is 'uid'.
-
-For LDAP directories with restricted access to objects or attributes
-Negotiate implements 'adminUser' and 'adminPassword'. adminUser must
-be a DN to an object with access to search for all relevant user
-objects and to look up attributes needed by the SP.
+Read the documentation of the LDAP auth module for more information.
 
 ### Subnet filtering
 

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -109,7 +109,7 @@ class Negotiate extends Auth\Source
         $configUtils = new Utils\Config();
         $this->keytab = $configUtils->getCertPath($cfg->getString('keytab'));
         $this->base = $cfg->getArrayizeString('base');
-        $this->attr = $cfg->getOptionalArrayizeString('attr', 'uid');
+        $this->attr = $cfg->getOptionalArrayizeString('attr', ['uid']);
         $this->subnet = $cfg->getOptionalArray('subnet', null);
         $this->admin_user = $cfg->getOptionalString('adminUser', null);
         $this->admin_pw = $cfg->getOptionalString('adminPassword', null);

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -300,7 +300,7 @@ class Negotiate extends Auth\Source
         }
         $uid = substr($user, 0, $pos);
 
-        /** @psalm-var \SimpleSAML\Module\ldap\Auth\Source\Ldap|null $source */
+        /** @var \SimpleSAML\Module\ldap\Auth\Source\Ldap|null $source */
         $source = Auth\Source::getById($this->backend);
         if ($source === null) {
             throw new Exception('Could not find authentication source with id ' . $this->backend);


### PR DESCRIPTION
Depends on https://github.com/simplesamlphp/simplesamlphp-module-ldap/pull/37 to be merged and released into v2.1

Updates the module to use the new major version of the LDAP-module. Drops the requirement to set all the ldap-connection details in the negotiate-authsource. Instead the backend-authsource is used.
The fallback-authsource can now also be a non-ldap source (backend and fallback are now differentiated).