### PR TITLE
Implement certificate-based channel binding

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -119,7 +119,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           # Should be the lowest supported version
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: ctype, date, dom, fileinfo, filter, hash, intl, ldap, mbstring, openssl, pcre, spl, xml
           tools: composer
           coverage: none
@@ -159,7 +159,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Install libkrb5-dev
@@ -225,7 +225,7 @@ jobs:
       fail-fast: true
       matrix:
         operating-system: [windows-latest]
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Setup PHP, with composer and extensions

--- a/composer.json
+++ b/composer.json
@@ -32,17 +32,17 @@
         }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-krb5": ">=1.1.5",
 
         "simplesamlphp/assert": "^1.0",
         "simplesamlphp/composer-module-installer": "^1.3.4",
-        "simplesamlphp/simplesamlphp": "^2.1",
-        "simplesamlphp/simplesamlphp-module-ldap": "^2.2.0",
-        "symfony/http-foundation": "^6.0"
+        "simplesamlphp/simplesamlphp": "^2.2",
+        "simplesamlphp/simplesamlphp-module-ldap": "^2.3.0",
+        "symfony/http-foundation": "^6.4"
     },
     "require-dev": {
-        "simplesamlphp/simplesamlphp-test-framework": "^1.5.5"
+        "simplesamlphp/simplesamlphp-test-framework": "^1.6.2"
     },
     "support": {
         "issues": "https://github.com/simplesamlphp/simplesamlphp-module-negotiate/issues",

--- a/docs/negotiate.md
+++ b/docs/negotiate.md
@@ -57,6 +57,7 @@ All configuration is handled in authsources.php:
     'realms' => [
         '*' => 'ldap',
     ],
+    'allowedCertificateHashes' => [],
     'fallback' => 'crypto-hash',
     'spn' => null,
 ],
@@ -191,6 +192,26 @@ disabling Negotiate for any given client. The pages simplly set/delete
 a cookie that Negotiate will look for when a client attempts AuthN.
 The help text in the JSON files should be locally overwritten to fully
 explain which clients are accepted by Negotiate.
+
+### Channel binding
+
+A shortage of Kerberos-over-HTTP is that there are no distinguished SPN's for HTTP- and HTTPS-services [1][1].
+This means that a ticket that's being transmitted over an insecure HTTP-connection can also be used for
+HTTPS-connections to the same host. Besides this, Kerberos is also known to be vulnerable for MitM-attacks
+where the service-label of the SPN can be altered when an alternative service is available on the same host [2][2].
+
+[1]: https://techcommunity.microsoft.com/t5/iis-support-blog/how-to-use-spns-when-you-configure-web-applications-thatare/ba-p/324648
+[2]: https://googleprojectzero.blogspot.com/2021/10/using-kerberos-for-authentication-relay.html
+
+To prevent this, certificate-based channel binding is supported by this module as of version v1.1.6.
+Syntax for this is:
+
+```php
+'allowedCertificateHashes' => [<SHA-256 finterprint 1>, <SHA-256 fingerprint 2>],
+```
+
+Usually this array will contain just the one fingerprint for the current HTTPS-certificate of this IdP, but multiple can be
+used in a certificate-rollover situation.
 
 ### Logout/Login loop and reauthenticating
 

--- a/docs/negotiate.md
+++ b/docs/negotiate.md
@@ -207,11 +207,14 @@ To prevent this, certificate-based channel binding is supported by this module a
 Syntax for this is:
 
 ```php
+'enforceChannelBinding' => true,
 'allowedCertificateHashes' => [<SHA-256 finterprint 1>, <SHA-256 fingerprint 2>],
 ```
 
 Usually this array will contain just the one fingerprint for the current HTTPS-certificate of this IdP, but multiple can be
 used in a certificate-rollover situation.
+If the `enforceChannelBinding` setting is set to `true`, clients that do not provide binding-info will automatically be sent
+to the fallback authsource.
 
 ### Logout/Login loop and reauthenticating
 

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -407,5 +407,7 @@ class Negotiate extends Auth\Source
             'tls-server-end-point',
             pack('H*', $hash),
         ));
+
+        return $binding;
     }
 }

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -156,7 +156,7 @@ class Negotiate extends Auth\Source
                     } else if (empty($this->allowedCertificateHashes)) {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate without channel binding.');
                         $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, null);
-                        $reply = $this->doAuthentication();
+                        $reply = $this->doAuthentication($auth);
                     } else {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate with channel binding.');
 
@@ -166,7 +166,7 @@ class Negotiate extends Auth\Source
                             $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, $binding);
 
                             try {
-                                $reply = $this->doAuthentication($hash);
+                                $reply = $this->doAuthentication($auth, $hash);
                             } catch (Exception $e) {
                                 continue;
                             }

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -191,6 +191,7 @@ class Negotiate extends Auth\Source
 
                 if ($reply) {
                     // success! krb TGS received
+                    /** @psalm-var \KRB5NegotiateAuth $auth */
                     $userPrincipalName = $auth->getAuthenticatedUser();
                     Logger::info('Negotiate - authenticate(): ' . $userPrincipalName . ' authenticated.');
 

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -218,7 +218,7 @@ class Negotiate extends Auth\Source
                         $state['Attributes'] = $lookup;
                         // Override the backend so logout will know what to look for
                         $state['LogoutState'] = [
-                            'negotiate:backend' => null,
+                            'negotiate:backend' => $this->backend,
                         ];
                         Logger::info('Negotiate - authenticate(): ' . $userPrincipalName . ' authorized.');
                         Auth\Source::completeAuth($state);

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -124,7 +124,7 @@ class Negotiate extends Auth\Source
 
         if (
             $disabled ||
-            (!empty($_COOKIE['NEGOTIATE_AUTOLOGIN_DISABLE_PERMANENT']) &&
+            (array_key_exists('NEGOTIATE_AUTOLOGIN_DISABLE_PERMANENT', $_COOKIE) &&
             $_COOKIE['NEGOTIATE_AUTOLOGIN_DISABLE_PERMANENT'] === 'true')
         ) {
             Logger::debug('Negotiate - session disabled. falling back');
@@ -313,7 +313,7 @@ class Negotiate extends Auth\Source
             return true;
         }
 
-        $ip = Request::createFromGlobals()->getClientIp();
+        $ip = Request::createFromGlobals()->getClientIp() ?? '127.0.0.1';
         Assert::notNull($ip, "Unable to determine client IP.");
 
         if (IpUtils::checkIp($ip, $this->subnet)) {

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -159,10 +159,12 @@ class Negotiate extends Auth\Source
                         $reply = $this->doAuthentication();
                     } else {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate with channel binding.');
-                        $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, $binding);
 
                         $hashes = str_replace(':', '', $this->allowedCertificateHashes);
                         foreach ($hashes as $hash) {
+                            $binding = $this->createBinding($hash);
+                            $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, $binding);
+
                             try {
                                 $reply = $this->doAuthentication($hash);
                             } catch (Exception $e) {
@@ -233,8 +235,6 @@ class Negotiate extends Auth\Source
 
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
-        $binding = $this->createBinding($hash);
-
         try {
             $reply = $auth->doAuthentication();
             if ($hash !== null) {

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -247,7 +247,7 @@ class Negotiate extends Auth\Source
 
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
-        if ($this->enforceChannelBinding === true && ($hash === null) || $auth->isChannelBound === false)) {
+        if ($this->enforceChannelBinding === true && (($hash === null) || ($auth->isChannelBound === false))) {
             throw new Error\Exception(
                 'Negotiate - doAuthenticate(): Channel binding is required, but the client '
                 . 'did not provide binding info.',

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -248,7 +248,7 @@ class Negotiate extends Auth\Source
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
         if ($this->enforceChannelBinding === true && ($hash === null) || $auth->isChannelBound === false)) {
-            throw new Exception(
+            throw new Error\Exception(
                 'Negotiate - doAuthenticate(): Channel binding is required, but the client '
                 . 'did not provide binding info.',
             );

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -231,7 +231,7 @@ class Negotiate extends Auth\Source
     }
 
 
-    private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): KRB5NegotiateAuth
+    private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
         $binding = $this->createBinding($hash);
 

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -23,6 +23,7 @@ use function phpversion;
 use function preg_split;
 use function sprintf;
 use function str_replace;
+use function strval;
 use function version_compare;
 
 /**
@@ -159,7 +160,7 @@ class Negotiate extends Auth\Source
                         $reply = $this->doAuthentication($auth);
                     } else if (empty($this->allowedCertificateHashes)) {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate without channel binding.');
-                        $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, null);
+                        $auth = new KRB5NegotiateAuth($this->keytab, $this->spn);
                         $reply = $this->doAuthentication($auth);
                     } else {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate with channel binding.');
@@ -270,7 +271,7 @@ class Negotiate extends Auth\Source
         } catch (Exception $e) {
             Logger::debug(sprintf(
                 'Negotiate - authenticate(): Authentication with channel binding failed using hash; %s.',
-                $hash,
+                strval($hash),
             ));
             throw $e;
         }

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -247,25 +247,29 @@ class Negotiate extends Auth\Source
 
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
-        if ($this->enforceChannelBinding === true && $auth->isChannelBound === false) {
+        if ($this->enforceChannelBinding === true && ($hash === null) || $auth->isChannelBound === false)) {
+            throw new Exception(
+                'Negotiate - doAuthenticate(): Channel binding is required, but the client '
+                . 'did not provide binding info.',
+            );
         }
 
         try {
             $reply = $auth->doAuthentication();
             if ($hash !== null) {
                 Logger::debug(sprintf(
-                    'Negotiate - authenticate(): Authentication with channel binding succeeded using hash; %s.',
+                    'Negotiate - doAuthenticate(): Authentication with channel binding succeeded using hash; %s.',
                     $hash,
                 ));
             } else {
                 Logger::debug(
-                    'Negotiate - authenticate(): Authentication without channel binding succeeded.',
+                    'Negotiate - doAuthenticate(): Authentication without channel binding succeeded.',
                 );
             }
             return $reply;
         } catch (Exception $e) {
             Logger::debug(sprintf(
-                'Negotiate - authenticate(): Authentication with channel binding failed using hash; %s.',
+                'Negotiate - doAuthenticate(): Authentication with channel binding failed using hash; %s.',
                 strval($hash),
             ));
             throw $e;

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -139,7 +139,7 @@ class Negotiate extends Auth\Source
         }
 
         Logger::debug('Negotiate - authenticate(): looking for authentication header');
-        if (!empty($_SERVER['HTTP_AUTHORIZATION'])) {
+        if (array_key_exists('HTTP_AUTHORIZATION', $_SERVER) && !empty($_SERVER['HTTP_AUTHORIZATION'])) {
             Logger::debug('Negotiate - authenticate(): Authentication header found');
 
             Assert::true(is_string($this->spn) || (is_int($this->spn) && ($this->spn === 0)) || is_null($this->spn));

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -152,7 +152,7 @@ class Negotiate extends Auth\Source
                     if (version_compare(phpversion('krb5'), '1.1.6', '<')) {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate (channel binding not available).');
                         $auth = new KRB5NegotiateAuth($this->keytab, $this->spn);
-                        $reply = $auth->doAuthentication($auth);
+                        $reply = $this->doAuthentication($auth);
                     } else if (empty($this->allowedCertificateHashes)) {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate without channel binding.');
                         $auth = new KRB5NegotiateAuth($this->keytab, $this->spn, null);

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -158,7 +158,7 @@ class Negotiate extends Auth\Source
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate (channel binding not available).');
                         $auth = new KRB5NegotiateAuth($this->keytab, $this->spn);
                         $reply = $this->doAuthentication($auth);
-                    } else if (empty($this->allowedCertificateHashes)) {
+                    } else if (empty($this->allowedCertificateHashes) && $this->enforceChannelBinding === false) {
                         Logger::debug('Negotiate - authenticate(): Trying to authenticate without channel binding.');
                         $auth = new KRB5NegotiateAuth($this->keytab, $this->spn);
                         $reply = $this->doAuthentication($auth);
@@ -190,14 +190,6 @@ class Negotiate extends Auth\Source
                 }
 
                 if ($reply) {
-                    if ($this->enforceChannelBinding === true && $auth->isChannelBound() === false) {
-                        Logger::warning(
-                            'Negotiate - authenticate(): Channel not bound, but channel binding '
-                            . 'is required by configuration. Falling back',
-                        );
-                        $this->fallBack($state);
-                    }
-
                     // success! krb TGS received
                     $userPrincipalName = $auth->getAuthenticatedUser();
                     Logger::info('Negotiate - authenticate(): ' . $userPrincipalName . ' authenticated.');
@@ -255,6 +247,9 @@ class Negotiate extends Auth\Source
 
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
+        if ($this->enforceChannelBinding === true && $auth->isChannelBound === false) {
+        }
+
         try {
             $reply = $auth->doAuthentication();
             if ($hash !== null) {

--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -247,7 +247,7 @@ class Negotiate extends Auth\Source
 
     private function doAuthentication(KRB5NegotiateAuth $auth, string $hash = null): bool
     {
-        if ($this->enforceChannelBinding === true && (($hash === null) || ($auth->isChannelBound === false))) {
+        if ($this->enforceChannelBinding === true && (($hash === null) || ($auth->isChannelBound() === false))) {
             throw new Error\Exception(
                 'Negotiate - doAuthenticate(): Channel binding is required, but the client '
                 . 'did not provide binding info.',

--- a/src/Controller/NegotiateController.php
+++ b/src/Controller/NegotiateController.php
@@ -73,7 +73,7 @@ class NegotiateController
      */
     public function __construct(
         Configuration $config,
-        Session $session
+        Session $session,
     ) {
         $this->config = $config;
         $this->session = $session;
@@ -164,7 +164,7 @@ class NegotiateController
             '/', // path
             '', // domain
             true, // secure
-            true // httponly
+            true, // httponly
         );
 
         $t = new Template($this->config, 'negotiate:enable.twig');
@@ -193,7 +193,7 @@ class NegotiateController
             '/', // path
             '', // domain
             true, // secure
-            true // httponly
+            true, // httponly
         );
 
         $t = new Template($this->config, 'negotiate:disable.twig');

--- a/tests/src/Controller/NegotiateControllerTest.php
+++ b/tests/src/Controller/NegotiateControllerTest.php
@@ -162,8 +162,8 @@ class NegotiateControllerTest extends TestCase
             {
                 return [
                     'LogoutState' => [
-                        'negotiate:backend' => 'foo'
-                    ]
+                        'negotiate:backend' => 'foo',
+                    ],
                 ];
             }
         });
@@ -206,7 +206,7 @@ class NegotiateControllerTest extends TestCase
         $request = Request::create(
             '/retry',
             'GET',
-            ['AuthState' => 'someState']
+            ['AuthState' => 'someState'],
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -216,8 +216,8 @@ class NegotiateControllerTest extends TestCase
             {
                 return [
                     'LogoutState' => [
-                        'negotiate:backend' => 'foo'
-                    ]
+                        'negotiate:backend' => 'foo',
+                    ],
                 ];
             }
         });
@@ -254,8 +254,8 @@ class NegotiateControllerTest extends TestCase
             {
                 return [
                     'LogoutState' => [
-                        'negotiate:backend' => 'foo'
-                    ]
+                        'negotiate:backend' => 'foo',
+                    ],
                 ];
             }
         });
@@ -300,7 +300,7 @@ class NegotiateControllerTest extends TestCase
     {
         $request = Request::create(
             '/retry',
-            'GET'
+            'GET',
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -323,7 +323,7 @@ class NegotiateControllerTest extends TestCase
         $request = Request::create(
             '/backend',
             'GET',
-            ['AuthState' => 'someState']
+            ['AuthState' => 'someState'],
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -333,8 +333,8 @@ class NegotiateControllerTest extends TestCase
             {
                 return [
                     'LogoutState' => [
-                        'negotiate:backend' => 'foo'
-                    ]
+                        'negotiate:backend' => 'foo',
+                    ],
                 ];
             }
         });
@@ -354,7 +354,7 @@ class NegotiateControllerTest extends TestCase
     {
         $request = Request::create(
             '/backend',
-            'GET'
+            'GET',
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);

--- a/tests/src/Controller/NegotiateControllerTest.php
+++ b/tests/src/Controller/NegotiateControllerTest.php
@@ -50,7 +50,7 @@ class NegotiateControllerTest extends TestCase
                 'module.enable' => ['negotiate' => true],
             ],
             '[ARRAY]',
-            'simplesaml'
+            'simplesaml',
         );
 
         $this->session = Session::getSessionFromRequest();
@@ -76,7 +76,7 @@ class NegotiateControllerTest extends TestCase
     {
         $request = Request::create(
             '/enable',
-            'GET'
+            'GET',
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -113,7 +113,7 @@ class NegotiateControllerTest extends TestCase
     {
         $request = Request::create(
             '/disable',
-            'GET'
+            'GET',
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -152,7 +152,7 @@ class NegotiateControllerTest extends TestCase
         $request = Request::create(
             '/retry',
             'GET',
-            ['AuthState' => 'someState']
+            ['AuthState' => 'someState'],
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);
@@ -244,7 +244,7 @@ class NegotiateControllerTest extends TestCase
         $request = Request::create(
             '/retry',
             'GET',
-            ['AuthState' => 'someState']
+            ['AuthState' => 'someState'],
         );
 
         $c = new Controller\NegotiateController($this->config, $this->session);


### PR DESCRIPTION
Depends on https://github.com/php/pecl-authentication-krb5/pull/3 to be merged and released.

@thijskh I don't expect you to understand too much of this PR because I know you don't use this module, but would you mind taking a look?

The 'deal' here is, we receive a ticket with a certain 'context'.. Context being the certificate fingerprint using while retrieving the ticket.  We compare the fingerprint received with the configured value to prevent MitM attacks.

Key is that the new option is optional; we can either leave it away to not perform this check, or we pass an array of certificate hashes and pass the test if any of the hashes are good. The complex part here that I'm worried about is the array of hashes being processed..

If either hash matches, authentication succeeds. If none match, we fail.