### PR TITLE
Update Negotiate.php - fix logout state reference

### DIFF
--- a/src/Auth/Source/Negotiate.php
+++ b/src/Auth/Source/Negotiate.php
@@ -423,7 +423,7 @@ class Negotiate extends Auth\Source
     public function logout(array &$state): void
     {
         // get the source that was used to authenticate
-        $authId = $state['LogoutState']['negotiate:backend'];
+        $authId = $state['negotiate:backend'];
         Logger::debug('Negotiate - logout has the following authId: "' . $authId . '"');
 
         if ($authId === null) {


### PR DESCRIPTION
The logout function referenced the `LogoutState` key in the state, which is not present during logouts.

This PR fixes the logout.